### PR TITLE
Fix shifting on failure conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language : scala
 
 scala:
   - 2.11.12
-  - 2.12.4
+  - 2.12.8
 
 cache:
   directories:
@@ -10,7 +10,7 @@ cache:
   - $HOME/.sbt
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 "project fs2-zk" test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
   - $HOME/.sbt
 
 jdk:
-  - openjdk8
+  - oraclejdk8
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION -Dfile.encoding=UTF8 "project fs2-zk" test

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Library does not have other dependencies than fs2 and zookeeper client itself:
 
 version  |    scala  |   fs2  |  zookeeper     
 ---------|-----------|--------|--------- 
-0.4.0    | 2.11, 2.12| 1.0.0  | 3.4.10   
+0.4.0    | 2.11, 2.12| 1.0.5  | 3.4.10   
 0.2.0    | 2.11, 2.12| 0.10.0 | 3.4.10   
 0.1.6    | 2.11, 2.12| 0.9.7  | 3.4.10   
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Library does not have other dependencies than fs2 and zookeeper client itself:
 
 version  |    scala  |   fs2  |  zookeeper     
 ---------|-----------|--------|--------- 
-0.4.0    | 2.11, 2.12| 1.0.5  | 3.4.10   
+0.4.0    | 2.11, 2.12| 1.0.0  | 3.4.10   
 0.2.0    | 2.11, 2.12| 0.10.0 | 3.4.10   
 0.1.6    | 2.11, 2.12| 0.9.7  | 3.4.10   
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val contributors = Seq(
 lazy val commonSettings = Seq(
   organization := "com.spinoco",
   scalaVersion := "2.11.12",
-  crossScalaVersions := Seq("2.11.12", "2.12.4"),
+  crossScalaVersions := Seq("2.11.12", "2.12.8"),
   scalacOptions ++= Seq(
     "-feature",
     "-deprecation",
@@ -22,16 +22,17 @@ lazy val commonSettings = Seq(
     "-Ywarn-value-discard",
     "-Ywarn-unused-import"
   ),
-  scalacOptions in (Compile, console) ~= {_.filterNot("-Ywarn-unused-import" == _)},
-  scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
+  scalacOptions in(Compile, console) ~= {
+    _.filterNot("-Ywarn-unused-import" == _)
+  },
+  scalacOptions in(Test, console) := (scalacOptions in(Compile, console)).value,
   libraryDependencies ++= Seq(
-    "org.scalatest" %% "scalatest" % "3.0.0" % "test"
-    , "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
-    , "org.slf4j" % "slf4j-simple" % "1.6.1" % "test" // uncomment this for logs when testing
-
-    , "co.fs2" %% "fs2-core" % "1.0.0"
-    , "co.fs2" %% "fs2-io" % "1.0.0"
-    , "org.apache.zookeeper" % "zookeeper" % "3.4.10"
+    "org.scalatest" %% "scalatest" % "3.0.0" % Test
+    , "org.scalacheck" %% "scalacheck" % "1.13.4" % Test
+    , "org.slf4j" % "slf4j-simple" % "1.6.1" % Test
+    , "co.fs2" %% "fs2-core" % "1.0.5"
+    , "co.fs2" %% "fs2-io" % "1.0.5"
+    , "org.apache.zookeeper" % "zookeeper" % "3.4.10" exclude("org.slf4j", "slf4j-log4j12")
 
   ),
   scmInfo := Some(ScmInfo(url("https://github.com/Spinoco/fs2-zk"), "git@github.com:Spinoco/fs2-zk.git")),
@@ -51,13 +52,17 @@ lazy val testSettings = Seq(
 )
 
 lazy val scaladocSettings = Seq(
-  scalacOptions in (Compile, doc) ++= Seq(
+  scalacOptions in(Compile, doc) ++= Seq(
     "-doc-source-url", scmInfo.value.get.browseUrl + "/tree/master€{FILE_PATH}.scala",
     "-sourcepath", baseDirectory.in(LocalRootProject).value.getAbsolutePath,
     "-implicits",
     "-implicits-show-all"
   ),
-  scalacOptions in (Compile, doc) ~= { _ filterNot { _ == "-Xfatal-warnings" } },
+  scalacOptions in(Compile, doc) ~= {
+    _ filterNot {
+      _ == "-Xfatal-warnings"
+    }
+  },
   autoAPIMappings := true
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2-1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")


### PR DESCRIPTION
Instead of using `<*`, we move to using Bracket's `guarantee` to ensure shifting will happen even if the computation fails. 

**Updates**
SBT 1.1.6 to SBT 1.2.8
Scala 2.12.4 to 2.12.8
FS2 1.0.0 to 1.0.5
Excluded `slf4j-log4j12` on Zookeeper as it was causing SLF4J to warn about multiple bindings
Travis build to use Scala 2.12.8 and switch Oracle JDK to OpenJDK
Update SBT plugins

Completes https://github.com/Spinoco/fs2-zk/issues/5