### PR TITLE
Update sbt to 1.3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
   directories:
   - $HOME/.ivy2
   - $HOME/.sbt
+  - $HOME/.cache/coursier
 
 jdk:
   - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,8 @@
 import com.typesafe.sbt.pgp.PgpKeys.publishSigned
 
+Global / onChangedBuildSource := ReloadOnSourceChanges
+ThisBuild / turbo := true
+
 val ReleaseTag = """^release/([\d\.]+a?)$""".r
 
 lazy val contributors = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.3.4


### PR DESCRIPTION
As the title suggests I upgraded the project to sbt 1.3.4, which I've found to be reasonably stable at work (not sure yet about 1.3.5).

I haven't tested the cache location, but it's according to the docs here: https://get-coursier.io/docs/cache